### PR TITLE
Add implements grammar

### DIFF
--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -324,7 +324,14 @@ module.exports = grammar({
 				choice('struct', 'union'),
 				field('name', $.identifier),
 				optional(field('generic_parameters', $.generic_parameters)),
+				optional(seq('implements', field('implements', $.implements))),
 				$._struct_body,
+			),
+
+		implements: ($) =>
+			seq(
+				choice($.type_reference_expression, $.qualified_type),
+				repeat(seq(',', choice($.type_reference_expression, $.qualified_type)))
 			),
 
 		_struct_body: ($) =>

--- a/tree_sitter_v/test/corpus/struct_declaration.txt
+++ b/tree_sitter_v/test/corpus/struct_declaration.txt
@@ -652,3 +652,52 @@ __global:
       (plain_type
         (type_reference_expression
           (identifier))))))
+
+================================================================================
+Struct with single explicit interface implementation
+================================================================================
+pub struct Foo implements Bar {
+    name string
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (struct_declaration
+    (visibility_modifiers)
+    (identifier)
+    (implements
+      (type_reference_expression
+        (identifier)))
+    (struct_field_declaration
+      (identifier)
+      (plain_type
+        (type_reference_expression
+          (identifier))))))
+
+================================================================================
+Struct with multiple explicit interface implementations
+================================================================================
+pub struct Foo implements Interface1, Interface2, qualified.Interface3 {
+    name string
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (struct_declaration
+    (visibility_modifiers)
+    (identifier)
+    (implements
+      (type_reference_expression
+        (identifier))
+      (type_reference_expression
+        (identifier))
+      (qualified_type
+        (reference_expression
+          (identifier))
+        (type_reference_expression
+          (identifier))))
+    (struct_field_declaration
+      (identifier)
+      (plain_type
+        (type_reference_expression
+          (identifier))))))


### PR DESCRIPTION
This PR changes tree-sitter-v grammar and adds implements interface syntax to struct declarations.

```vlang
struct Name implements Interface, qualifier.Interface2 {
  name string
}
```